### PR TITLE
Changed open price from 'open' key to 'regularMarketPreviousClose' key

### DIFF
--- a/stock_colors.py
+++ b/stock_colors.py
@@ -27,7 +27,7 @@ def getStockChangeToday(ticker):
     info=yf.Ticker(ticker).info
     current_price = info['regularMarketPrice']
     log("Current Price: " + str(current_price))
-    open_price = info['open']
+    open_price = info['regularMarketPreviousClose']
     log("Day open price: " + str(open_price))
     return get_percent_difference(current_price, open_price)
 


### PR DESCRIPTION
Changed the attribute of the stock info object that is used to determine starting price. It has changed from 'open' to 'regularMarketPreviousClose' as the ladder seems to be more wildly used by different stock ticker's info objects